### PR TITLE
normalize top-level help

### DIFF
--- a/lib/heroku/command/pipeline.rb
+++ b/lib/heroku/command/pipeline.rb
@@ -4,7 +4,7 @@ require 'heroku/api/config_vars'
 require 'rest_client'
 require 'net/http'
 
-# Continuous delivery pipeline actions
+# manage continuous delivery pipelines
 #
 class Heroku::Command::Pipeline < Heroku::Command::BaseWithApp
 


### PR DESCRIPTION
Fixes this inconsistency:

``` console
$ heroku help | grep Cont -C 3
  orgs         # 
  pg           #  manage heroku-postgresql databases
  pgbackups    #  manage backups of heroku postgresql databases
  pipeline     #  Continuous delivery pipeline actions
  plugins      #  manage plugins to the heroku gem
  ssl          #  manage ssl certificates for an app
  stack        #  manage the stack for an app
```
